### PR TITLE
Resolve high-priority Dependabot alerts for frontend and Python dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@vitejs/plugin-react": "^4.3.1",
     "algoliasearch": "^4.23.3",
     "autoprefixer": "^10.4.19",
-    "axios": "^1.13.5",
+    "axios": "^1.15.2",
     "better-react-mathjax": "^2.0.3",
     "django-vite-plugin": "4.1.2",
     "downshift": "^9.0.6",
@@ -63,8 +63,8 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@types/react-text-truncate": "^0.14.4",
-    "@vitest/coverage-v8": "^1",
-    "@vitest/ui": "^2.1.1",
+    "@vitest/coverage-v8": "^4.1.0",
+    "@vitest/ui": "^4.1.0",
     "eslint": "9.x",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
@@ -78,11 +78,16 @@
     "typescript": "^5.2.2",
     "typescript-eslint": "^7.13.0",
     "vite": "^5",
-    "vitest": "^1"
+    "vitest": "^4.1.0"
   },
   "resolutions": {
     "strip-ansi": "6.0.1",
-    "@types/react": "18.3.28"
+    "@types/react": "18.3.28",
+    "lodash": "4.18.0",
+    "picomatch": "4.0.4",
+    "vitest": "4.1.0",
+    "@vitest/ui": "4.1.0",
+    "@vitest/coverage-v8": "4.1.0"
   },
   "packageManager": "yarn@4.12.0",
   "volta": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@vitejs/plugin-react": "^4.3.1",
     "algoliasearch": "^4.23.3",
     "autoprefixer": "^10.4.19",
-    "axios": "^1.13.5",
+    "axios": "^1.15.2",
     "better-react-mathjax": "^2.0.3",
     "django-vite-plugin": "4.1.2",
     "downshift": "^9.0.6",
@@ -82,7 +82,9 @@
   },
   "resolutions": {
     "strip-ansi": "6.0.1",
-    "@types/react": "18.3.28"
+    "@types/react": "18.3.28",
+    "lodash": "4.18.0",
+    "picomatch": "4.0.4"
   },
   "packageManager": "yarn@4.12.0",
   "volta": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ dependencies = [
     "algoliasearch>=3.0.0",
     "algoliasearch-django>=3.0.0",
     "dj-database-url>=2.2.0",
-    "django>=5.1.1",
+    "django>=6.0.4",
     "django-after-response>=0.2.2",
     "django-allauth[socialaccount]>=64.2.1",
     "django-autoslug>=1.9.9",
@@ -23,11 +23,12 @@ dependencies = [
     "django-vite-plugin>=3.0.4",
     "djangorestframework>=3.15.2",
     "gunicorn>=23.0.0",
-    "pillow>=10.4.0",
+    "pillow>=12.2.0",
     "psycopg>=3.2.1",
     "psycopg2-binary>=2.9.9",
     "pyjwt[crypto]>=2.9.0",
     "python-dotenv>=1.0.1",
+    "urllib3>=2.7.0",
     "sentry-sdk[django]>=2.13.0",
 ]
 


### PR DESCRIPTION
## Summary

This PR addresses the high-priority Dependabot security alerts currently affecting PsychoModels’ frontend and backend dependency stack.

The changes update the project’s declared dependency ranges for vulnerable packages and add Yarn resolutions for transitive packages where needed. The affected packages include:

- `axios`
- `urllib3`
- `lodash`
- `Pillow`
- `Django`
- `picomatch`
- `vitest`
- `@vitest/ui`
- `@vitest/coverage-v8`

These updates are intended to move the project onto patched dependency versions for the high-severity alerts reported by GitHub Dependabot.

---

## Background

GitHub Dependabot reported several high-severity vulnerabilities affecting both npm and Python dependencies used by PsychoModels.

The original set of high-priority alerts included vulnerabilities in:

- `axios`
- `urllib3`
- `lodash`
- `Pillow`
- `Django`
- `picomatch`

After the first dependency update, an additional high-severity Vitest advisory was reported:

- `GHSA-5xrq-8626-4rwp`: “When Vitest UI server is listening, arbitrary file can be read and executed”

This PR combines the dependency updates from the previous two security-update PRs into a single, consolidated branch suitable for merging into the main repository.

---

## Security alerts addressed

### Frontend / npm alerts

#### `axios`

Dependabot reported a high-severity `axios` vulnerability:

- Advisory: `GHSA-q8qp-cvcw-x6jj`
- Package: `axios`
- Vulnerable range: `>=1.0.0, <1.15.2`
- Patched version: `1.15.2`
- Reported issue: prototype-pollution read-side gadgets in the HTTP adapter that may allow credential injection and request hijacking.

This PR updates the direct `axios` dependency from the vulnerable range to:

```json
"axios": "^1.15.2"